### PR TITLE
Separate Transcript and Summary endpoints

### DIFF
--- a/examples/quick_dev.rs
+++ b/examples/quick_dev.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use serde_json::json;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -9,13 +8,10 @@ async fn main() -> Result<()> {
 
 	hc.do_get("/").await?.print().await?;
 
-	hc.do_post(
-		"/transcript",
-		json!({"url": "https://www.youtube.com/watch?v=dNY4FKXwTsM"}),
-	)
-	.await?
-	.print()
-	.await?;
+	hc.do_get("/summary?url=https://www.youtube.com/watch?v=dNY4FKXwTsM")
+		.await?
+		.print()
+		.await?;
 
 	Ok(())
 }

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<()> {
 		base_url,
 	} = Config::build().unwrap();
 
-	let transcript = transcript::get_by_url(&url).await?;
+	let transcript = transcript::summarize_by_url(&url).await?;
 	let text = transcript::clean_vtt(&transcript);
 
 	let client = CompletionClient::build(api_key, &base_url, model)?;

--- a/src/web/routes/transcript.rs
+++ b/src/web/routes/transcript.rs
@@ -12,7 +12,7 @@ struct TranscriptParams {
 }
 
 #[debug_handler]
-async fn transcript(
+async fn summarize(
 	Json(TranscriptParams { url, raw }): Json<TranscriptParams>,
 ) -> (StatusCode, Json<Value>) {
 	println!("post transcript: {url:?}, raw {raw:?}");
@@ -41,5 +41,5 @@ async fn transcript(
 }
 
 pub fn routes() -> Router {
-	Router::new().route("/transcript", post(transcript))
+	Router::new().route("/summary", post(summarize))
 }

--- a/src/web/routes/transcript.rs
+++ b/src/web/routes/transcript.rs
@@ -1,5 +1,5 @@
 use crate::web::services::transcript;
-use axum::{http::StatusCode, routing::post, Json, Router};
+use axum::{extract::Query, http::StatusCode, routing::get, Json, Router};
 use axum_macros::debug_handler;
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -12,7 +12,7 @@ struct TranscriptParams {
 }
 
 async fn transcript(
-	Json(TranscriptParams { url, raw }): Json<TranscriptParams>,
+	Query(TranscriptParams { url, raw }): Query<TranscriptParams>,
 ) -> (StatusCode, Json<Value>) {
 	println!("GET transcript {url:?}, raw {raw:?}");
 
@@ -39,25 +39,24 @@ async fn transcript(
 	}
 }
 
+#[derive(Deserialize)]
+struct SummaryParams {
+	url: String,
+}
 #[debug_handler]
 async fn summarize(
-	Json(TranscriptParams { url, raw }): Json<TranscriptParams>,
+	Query(SummaryParams { url }): Query<SummaryParams>,
 ) -> (StatusCode, Json<Value>) {
-	println!("post transcript: {url:?}, raw {raw:?}");
-
 	match transcript::summarize_by_url(&url).await {
-		Ok(transcript) => {
-			println!("got transcript");
-			(
-				StatusCode::OK,
-				Json(json!(
-						{
-							"url": url,
-							"transcript": transcript
-						}
-				)),
-			)
-		}
+		Ok(transcript) => (
+			StatusCode::OK,
+			Json(json!(
+					{
+						"url": url,
+						"transcript": transcript
+					}
+			)),
+		),
 		Err(e) => {
 			println!("failed to get transcript {e:?}");
 			(
@@ -71,6 +70,6 @@ async fn summarize(
 pub fn routes() -> Router {
 	// todo make these get requests
 	Router::new()
-		.route("/summary", post(summarize))
-		.route("/transcript", post(transcript))
+		.route("/summary", get(summarize))
+		.route("/transcript", get(transcript))
 }

--- a/src/web/routes/transcript.rs
+++ b/src/web/routes/transcript.rs
@@ -11,13 +11,41 @@ struct TranscriptParams {
 	raw: bool,
 }
 
+async fn transcript(
+	Json(TranscriptParams { url, raw }): Json<TranscriptParams>,
+) -> (StatusCode, Json<Value>) {
+	println!("GET transcript {url:?}, raw {raw:?}");
+
+	match transcript::get_transcript_by_url(&url, raw).await {
+		Ok(transcript) => {
+			println!("got transcript");
+			(
+				StatusCode::OK,
+				Json(json!(
+						{
+							"url": url,
+							"transcript": transcript
+						}
+				)),
+			)
+		}
+		Err(e) => {
+			println!("failed to get transcript {e:?}");
+			(
+				StatusCode::INTERNAL_SERVER_ERROR,
+				Json(json!({"message": "internal server error"})),
+			)
+		}
+	}
+}
+
 #[debug_handler]
 async fn summarize(
 	Json(TranscriptParams { url, raw }): Json<TranscriptParams>,
 ) -> (StatusCode, Json<Value>) {
 	println!("post transcript: {url:?}, raw {raw:?}");
 
-	match transcript::get_by_url(&url).await {
+	match transcript::summarize_by_url(&url).await {
 		Ok(transcript) => {
 			println!("got transcript");
 			(
@@ -41,5 +69,8 @@ async fn summarize(
 }
 
 pub fn routes() -> Router {
-	Router::new().route("/summary", post(summarize))
+	// todo make these get requests
+	Router::new()
+		.route("/summary", post(summarize))
+		.route("/transcript", post(transcript))
 }

--- a/src/web/services/transcript.rs
+++ b/src/web/services/transcript.rs
@@ -1,5 +1,6 @@
 use crate::config::Config;
 use crate::error::Result;
+use crate::web::routes::transcript;
 use crate::web::services::ai::completions::CompletionClient;
 use crate::web::services::ai::prompt::ARTICLE_TEMPLATE;
 use core::str;
@@ -20,9 +21,26 @@ const RETRIES: &str = "10";
 const OUTPUT_TEMPLATE: &str = "%(id)s";
 const PROXY: &str = "PROXY";
 
-pub async fn get_by_url(url: &str) -> Result<String> {
+const RAW_EXT: &str = "en.vtt";
+const CLEAN_EXT: &str = "en.clean";
+const SUMMARY_EXT: &str = "md";
+
+fn get_artifact_dir() -> PathBuf {
+	env::var("OUTPUT_PATH")
+		.unwrap_or_else(|_| "./transcripts".to_string())
+		.into()
+}
+
+fn get_artifact_path(url: &str, extension: &str) -> Option<PathBuf> {
+	let mut path = get_artifact_dir().join(get_video_id(url)?);
+	path.set_extension(extension);
+
+	Some(path)
+}
+
+pub async fn get_transcript_by_url(url: &str, raw: bool) -> Result<String> {
 	// ytdlp will write to a file in the output dir
-	let output_path = env::var("OUTPUT_PATH").unwrap_or_else(|_| "./transcripts".to_string());
+	let output_path = get_artifact_dir();
 
 	// TODO try to read from cache instead
 	// if fs::exists(&output_path)? {
@@ -31,7 +49,7 @@ pub async fn get_by_url(url: &str) -> Result<String> {
 
 	let proxy = env::var(PROXY).map_err(|_| "proxy is not set")?;
 
-	let url = url.to_owned();
+	let owned_url = url.to_owned();
 	let join_handle = tokio::spawn(async move {
 		let mut cmd = Command::new(YTDLP);
 		let cmd = cmd.args([
@@ -52,9 +70,12 @@ pub async fn get_by_url(url: &str) -> Result<String> {
 			"--proxy",
 			&proxy,
 			"--paths",
-			&output_path,
+			output_path
+				.as_path()
+				.to_str()
+				.expect("path should always be valid utf8"),
 			"-i",
-			&url,
+			&owned_url,
 		]);
 
 		cmd.output()
@@ -77,16 +98,26 @@ pub async fn get_by_url(url: &str) -> Result<String> {
 		.into());
 	}
 
-	let stdout = str::from_utf8(&stdout)?;
-	let mut path = PathBuf::from(stdout.trim_end());
-	path.set_extension("en.vtt");
+	let raw_path = get_artifact_path(&url, RAW_EXT).expect("video id must exist at this point");
 
-	let transcript = fs::read_to_string(&path)
-		.map_err(|e| format!("could not find path {}: {e}", path.display()))?;
+	let transcript = fs::read_to_string(&raw_path)
+		.map_err(|e| format!("could not find path {}: {e}", raw_path.display()))?;
+
+	println!("got the transcript!");
+	Ok(if raw {
+		transcript
+	} else {
+		clean_vtt(&transcript)
+	})
+}
+
+pub async fn summarize_by_url(url: &str) -> Result<String> {
+	get_artifact_dir();
+	let transcript = get_transcript_by_url(url, false).await?;
 
 	let clean = clean_vtt(&transcript);
-	path.set_extension("clean.en.vtt");
-	fs::write(&path, &clean).unwrap();
+	// path.set_extension("clean.en.vtt");
+	// fs::write(&path, &clean).unwrap();
 
 	let Config {
 		api_key,
@@ -99,8 +130,8 @@ pub async fn get_by_url(url: &str) -> Result<String> {
 		.post(ARTICLE_TEMPLATE, &clean)
 		.await?;
 
-	path.set_extension("summary.md");
-	fs::write(path, &res).unwrap();
+	// path.set_extension("summary.md");
+	// fs::write(path, &res).unwrap();
 
 	Ok(res)
 }

--- a/src/web/services/transcript.rs
+++ b/src/web/services/transcript.rs
@@ -1,6 +1,5 @@
 use crate::config::Config;
 use crate::error::Result;
-use crate::web::routes::transcript;
 use crate::web::services::ai::completions::CompletionClient;
 use crate::web::services::ai::prompt::ARTICLE_TEMPLATE;
 use core::str;
@@ -98,21 +97,17 @@ pub async fn get_transcript_by_url(url: &str, raw: bool) -> Result<String> {
 	let transcript = fs::read_to_string(&raw_path)
 		.map_err(|e| format!("could not find path {}: {e}", raw_path.display()))?;
 
+	let clean = clean_vtt(&transcript);
+	let clean_path = get_artifact_path(url, CLEAN_EXT).expect("video id must exist at this point");
+	// TODO more generic caching facade
+	fs::write(&clean_path, &clean)?;
+
 	println!("got the transcript!");
-	Ok(if raw {
-		transcript
-	} else {
-		clean_vtt(&transcript)
-	})
+	Ok(if raw { transcript } else { clean })
 }
 
 pub async fn summarize_by_url(url: &str) -> Result<String> {
-	get_artifact_dir();
 	let transcript = get_transcript_by_url(url, false).await?;
-
-	let clean = clean_vtt(&transcript);
-	// path.set_extension("clean.en.vtt");
-	// fs::write(&path, &clean).unwrap();
 
 	let Config {
 		api_key,
@@ -122,11 +117,11 @@ pub async fn summarize_by_url(url: &str) -> Result<String> {
 	} = Config::build().unwrap();
 	let client = CompletionClient::build(api_key, &base_url, model)?;
 	let res = client
-		.post(ARTICLE_TEMPLATE, &clean)
+		.post(ARTICLE_TEMPLATE, &transcript)
 		.await?;
 
-	// path.set_extension("summary.md");
-	// fs::write(path, &res).unwrap();
+	let path = get_artifact_path(url, SUMMARY_EXT).expect("video id must be valid at this point");
+	fs::write(path, &res)?;
 
 	Ok(res)
 }

--- a/src/web/services/transcript.rs
+++ b/src/web/services/transcript.rs
@@ -53,8 +53,6 @@ pub async fn get_transcript_by_url(url: &str, raw: bool) -> Result<String> {
 	let join_handle = tokio::spawn(async move {
 		let mut cmd = Command::new(YTDLP);
 		let cmd = cmd.args([
-			"--print",
-			"filename",
 			"--no-simulate",
 			"--write-subs",
 			"--write-auto-subs",
@@ -81,11 +79,8 @@ pub async fn get_transcript_by_url(url: &str, raw: bool) -> Result<String> {
 		cmd.output()
 	});
 
-	let Output {
-		status,
-		stdout,
-		stderr,
-	} = timeout(Duration::from_secs(20), join_handle).await???;
+	// TODO service unavailable code if takes longer than timeout. This will depend based on proxy and server location
+	let Output { status, stderr, .. } = timeout(Duration::from_secs(30), join_handle).await???;
 
 	if !status.success() {
 		return Err(format!(
@@ -98,7 +93,7 @@ pub async fn get_transcript_by_url(url: &str, raw: bool) -> Result<String> {
 		.into());
 	}
 
-	let raw_path = get_artifact_path(&url, RAW_EXT).expect("video id must exist at this point");
+	let raw_path = get_artifact_path(url, RAW_EXT).expect("video id must exist at this point");
 
 	let transcript = fs::read_to_string(&raw_path)
 		.map_err(|e| format!("could not find path {}: {e}", raw_path.display()))?;


### PR DESCRIPTION
- **rename transcript to summary**
- **Use helper function to get file output instead of reading stdout**
- **Change timeout to 30 seconds**
- **use helper function in other locations to cache summary**
- **use get instead of post for endpoints**
