### PR TITLE
json errors

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -53,8 +53,12 @@
         output.innerHTML = `<p>Loading summary for <a href=${link}>${link}</a>...</p><p>It may take a 30-60 seconds if uncached</p>`;
         fetch(`/summary?url=${link}`)
           .then((response) => response.json())
-          .then(({ summary }) => {
-            console.log({ summary });
+          .then(({ summary, error, message }) => {
+            console.log({ summary, error, message });
+            if (error) {
+              output.innerHTML = `<p>Error: ${message}</p>`;
+              return;
+            }
             output.innerHTML = marked.parse(summary);
           })
           .catch((error) => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 use core::fmt::{self, Display, Formatter};
 
 use crate::web::utils::{YTUrl, yt_url};
-use axum::response::IntoResponse;
+use axum::{Json, response::IntoResponse};
 use derive_more::From;
 use reqwest::StatusCode;
 use tokio::{task::JoinError, time::error::Elapsed};
@@ -47,25 +47,41 @@ impl From<&str> for Error {
 	}
 }
 
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
+pub struct ErrorMessage {
+	pub error: bool,
+	pub message: String,
+}
+fn error_response(status: StatusCode, s: impl Into<String>) -> (StatusCode, Json<ErrorMessage>) {
+	(
+		status,
+		Json(ErrorMessage {
+			error: true,
+			message: s.into(),
+		}),
+	)
+}
+
 impl IntoResponse for Error {
 	fn into_response(self) -> axum::response::Response {
 		use Error as E;
 		event!(Level::WARN, error=?self);
+
 		match self {
 			E::EnvMissingOrInvalid(_) | E::EnvParse(_) => {
-				(StatusCode::SERVICE_UNAVAILABLE, "Service Unavailable").into_response()
+				error_response(StatusCode::SERVICE_UNAVAILABLE, "Service Unavailable")
 			}
-			E::Timeout(_) => (StatusCode::GATEWAY_TIMEOUT, "Gateway Timeout").into_response(),
-			E::YtUrl(e) => (StatusCode::BAD_REQUEST, e.to_string()).into_response(),
-			E::CaptionsUnavailable(url) => (
+			E::Timeout(_) => error_response(StatusCode::GATEWAY_TIMEOUT, "Gateway Timeout"),
+			E::YtUrl(e) => error_response(StatusCode::BAD_REQUEST, e.to_string()),
+			E::CaptionsUnavailable(url) => error_response(
 				StatusCode::NOT_FOUND,
 				format!("Captions not available for URL: {}", url.as_str()),
-			)
-				.into_response(),
+			),
 			E::Sqlx(_) | E::Reqwest(_) | E::Join(_) | E::Io(_) | E::Custom(_) => {
-				(StatusCode::INTERNAL_SERVER_ERROR, "Unhandled Server Error").into_response()
+				error_response(StatusCode::INTERNAL_SERVER_ERROR, "Unhandled Server Error")
 			}
 		}
+		.into_response()
 	}
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,28 +1,27 @@
 use core::fmt::{self, Display, Formatter};
 
-use crate::web::utils::YTUrl;
+use crate::web::utils::{YTUrl, yt_url};
 use axum::response::IntoResponse;
 use derive_more::From;
 use reqwest::StatusCode;
 use tokio::{task::JoinError, time::error::Elapsed};
 use tracing::{Level, event};
-use url::Url;
 
 pub type Result<T> = core::result::Result<T, Error>;
 
 #[derive(Debug, From)]
 pub enum Error {
-	EnvMissing(&'static str),
+	EnvMissingOrInvalid(&'static str),
 	#[from]
 	EnvParse(dotenvy::Error),
 
 	CaptionsUnavailable(YTUrl),
-	UnsupportedUrl(Url),
+
+	#[from]
+	YtUrl(yt_url::Error),
 
 	#[from]
 	Reqwest(reqwest::Error),
-	#[from]
-	Url(url::ParseError),
 	#[from]
 	Timeout(Elapsed),
 	#[from]
@@ -53,14 +52,11 @@ impl IntoResponse for Error {
 		use Error as E;
 		event!(Level::WARN, error=?self);
 		match self {
-			E::EnvMissing(_) | E::EnvParse(_) => {
+			E::EnvMissingOrInvalid(_) | E::EnvParse(_) => {
 				(StatusCode::SERVICE_UNAVAILABLE, "Service Unavailable").into_response()
 			}
 			E::Timeout(_) => (StatusCode::GATEWAY_TIMEOUT, "Gateway Timeout").into_response(),
-			E::Url(_) => (StatusCode::BAD_REQUEST, "Invalid URL").into_response(),
-			E::UnsupportedUrl(url) => {
-				(StatusCode::BAD_REQUEST, format!("Unsupported URL: {url}")).into_response()
-			}
+			E::YtUrl(e) => (StatusCode::BAD_REQUEST, e.to_string()).into_response(),
 			E::CaptionsUnavailable(url) => (
 				StatusCode::NOT_FOUND,
 				format!("Captions not available for URL: {}", url.as_str()),

--- a/src/web/clients/completions.rs
+++ b/src/web/clients/completions.rs
@@ -84,12 +84,15 @@ impl CompletionClient {
 
 		load_env()?;
 
-		let api_key = env::var(OPEN_AI_API_KEY).map_err(|_| Error::EnvMissing(OPEN_AI_API_KEY))?;
-		let model = env::var(OPEN_AI_MODEL).map_err(|_| Error::EnvMissing(OPEN_AI_MODEL))?;
+		let api_key =
+			env::var(OPEN_AI_API_KEY).map_err(|_| Error::EnvMissingOrInvalid(OPEN_AI_API_KEY))?;
+		let model =
+			env::var(OPEN_AI_MODEL).map_err(|_| Error::EnvMissingOrInvalid(OPEN_AI_MODEL))?;
 		let url = env::var(OPEN_AI_BASE_URL)
-			.map_err(|_| Error::EnvMissing(OPEN_AI_BASE_URL))?
+			.map_err(|_| Error::EnvMissingOrInvalid(OPEN_AI_BASE_URL))?
 			.parse::<Url>()
-			.and_then(|x| x.join(COMPLETIONS_PATH))?;
+			.and_then(|x| x.join(COMPLETIONS_PATH))
+			.map_err(|_| Error::EnvMissingOrInvalid(OPEN_AI_BASE_URL))?;
 
 		Ok(Self {
 			model,

--- a/src/web/services/youtube.rs
+++ b/src/web/services/youtube.rs
@@ -27,8 +27,9 @@ impl YtService {
 		const YOUTUBE_RETRIES: &str = "YOUTUBE_RETRIES";
 		load_env()?;
 
-		let proxy = std::env::var(YOUTUBE_PROXY).map_err(|_| Error::EnvMissing(YOUTUBE_PROXY))?;
-		let proxy = Url::parse(&proxy)?;
+		let proxy =
+			std::env::var(YOUTUBE_PROXY).map_err(|_| Error::EnvMissingOrInvalid(YOUTUBE_PROXY))?;
+		let proxy = Url::parse(&proxy).map_err(|_| Error::EnvMissingOrInvalid(YOUTUBE_PROXY))?;
 		let retries = std::env::var(YOUTUBE_RETRIES)
 			.ok()
 			.and_then(|s| s.parse::<u8>().ok())

--- a/src/web/utils.rs
+++ b/src/web/utils.rs
@@ -1,87 +1,112 @@
-use crate::error::{Error, Result};
-use reqwest::Url;
-use std::borrow::Cow;
+pub use yt_url::YTUrl;
 
-const VIDEO_PARAM: &str = "v";
+pub mod yt_url {
+	pub use crate::web::utils::yt_url::error::{Error, Result};
+	use reqwest::Url;
+	use std::borrow::Cow;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct YTUrl {
-	url: Url,
-	id: String,
-}
+	const VIDEO_PARAM: &str = "v";
 
-impl TryFrom<Url> for YTUrl {
-	type Error = Error;
+	#[derive(Debug, Clone, PartialEq, Eq)]
+	pub struct YTUrl {
+		url: Url,
+		id: String,
+	}
 
-	fn try_from(url: Url) -> Result<Self> {
-		const YOUTUBE: &str = "youtube";
-		if let Some(host) = url.host_str()
-			&& host.contains(YOUTUBE)
-			&& let Some(id) = Self::try_get_id(&url)
-		{
-			let id = id.to_string();
-			Ok(Self { url, id })
-		} else {
-			Err(Error::UnsupportedUrl(url))
+	impl TryFrom<Url> for YTUrl {
+		type Error = Error;
+
+		fn try_from(url: Url) -> Result<Self> {
+			const YOUTUBE: &str = "youtube";
+			if let Some(host) = url.host_str()
+				&& host.contains(YOUTUBE)
+				&& let Some(id) = Self::try_get_id(&url)
+			{
+				let id = id.to_string();
+				Ok(Self { url, id })
+			} else {
+				Err(Error::Unsupported(url.into()))
+			}
 		}
 	}
-}
 
-impl TryFrom<&str> for YTUrl {
-	type Error = Error;
+	impl TryFrom<&str> for YTUrl {
+		type Error = Error;
 
-	fn try_from(url: &str) -> Result<Self> {
-		let url = Url::parse(url)?;
-		Self::try_from(url)
-	}
-}
-
-impl YTUrl {
-	pub fn as_url(&self) -> &Url {
-		&self.url
+		fn try_from(url: &str) -> Result<Self> {
+			let url = Url::parse(url).map_err(|_| Error::Invalid(url.into()))?;
+			Self::try_from(url)
+		}
 	}
 
-	pub fn as_str(&self) -> &str {
-		self.url.as_str()
+	impl YTUrl {
+		pub fn as_url(&self) -> &Url {
+			&self.url
+		}
+
+		pub fn as_str(&self) -> &str {
+			self.url.as_str()
+		}
+
+		fn try_get_id(url: &Url) -> Option<Cow<'_, str>> {
+			url.query_pairs()
+				.find(|(key, _)| key == VIDEO_PARAM)
+				.map(|(_, id)| id)
+		}
+
+		pub fn id(&self) -> &str {
+			&self.id
+		}
 	}
 
-	fn try_get_id(url: &Url) -> Option<Cow<'_, str>> {
-		url.query_pairs()
-			.find(|(key, _)| key == VIDEO_PARAM)
-			.map(|(_, id)| id)
+	pub mod error {
+
+		#[derive(Debug, Clone, PartialEq, Eq)]
+		pub enum Error {
+			Unsupported(String),
+			Invalid(String),
+		}
+
+		pub type Result<T> = std::result::Result<T, Error>;
+
+		impl std::fmt::Display for Error {
+			fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+				match self {
+					Error::Unsupported(url) => write!(f, "Unsupported URL: {url}"),
+					Error::Invalid(url) => write!(f, "Invalid URL: {url}"),
+				}
+			}
+		}
+
+		impl std::error::Error for Error {}
 	}
 
-	pub fn id(&self) -> &str {
-		&self.id
-	}
-}
+	#[cfg(test)]
+	mod tests {
+		use super::*;
 
-#[cfg(test)]
-mod tests {
-	use super::*;
+		const YT_URL: &str = "https://www.youtube.com/watch?v=DjcC6p_8fpE&pp=ygUWamFjb2IgYXNwZXIgdHlwZXNjcmlwdA%3D%3D";
+		const YT_ID: &str = "DjcC6p_8fpE";
 
-	const YT_URL: &str =
-		"https://www.youtube.com/watch?v=DjcC6p_8fpE&pp=ygUWamFjb2IgYXNwZXIgdHlwZXNjcmlwdA%3D%3D";
-	const YT_ID: &str = "DjcC6p_8fpE";
+		#[test]
+		fn should_get_video_id() -> Result<()> {
+			let url = YTUrl::try_from(YT_URL)?;
 
-	#[test]
-	fn should_get_video_id() -> Result<()> {
-		let url = YTUrl::try_from(YT_URL)?;
+			assert_eq!(url.id(), YT_ID);
 
-		assert_eq!(url.id(), YT_ID);
+			Ok(())
+		}
 
-		Ok(())
-	}
+		#[test]
+		fn invalid_host() {
+			let invalid_url = "https://lasagna.com/watch?v=DjcC6p_8fpE";
+			YTUrl::try_from(invalid_url).unwrap_err();
+		}
 
-	#[test]
-	fn invalid_host() {
-		let invalid_url = "https://lasagna.com/watch?v=DjcC6p_8fpE";
-		YTUrl::try_from(invalid_url).unwrap_err();
-	}
-
-	#[test]
-	fn missing_v_param() {
-		let invalid_url = "https://youtube.com/watch";
-		YTUrl::try_from(invalid_url).unwrap_err();
+		#[test]
+		fn missing_v_param() {
+			let invalid_url = "https://youtube.com/watch";
+			YTUrl::try_from(invalid_url).unwrap_err();
+		}
 	}
 }

--- a/tests/routes.rs
+++ b/tests/routes.rs
@@ -84,12 +84,13 @@ async fn should_get_and_cache_transcript(pool: PgPool) -> Result<()> {
 
 #[sqlx::test]
 async fn invalid_url(pool: PgPool) -> Result<()> {
+	let invalid_url = "uhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh";
 	let routes = routes(pool);
 
 	let response = routes
 		.oneshot(
 			Request::builder()
-				.uri("/transcript?url=invalid_url")
+				.uri(format!("/transcript?url={invalid_url}"))
 				.body(Body::empty())
 				.unwrap(),
 		)
@@ -100,7 +101,8 @@ async fn invalid_url(pool: PgPool) -> Result<()> {
 
 	let body = body_to_string(response).await?;
 
-	assert_eq!(body, "Invalid URL");
+	assert!(body.contains("Invalid URL"));
+	assert!(body.contains(invalid_url));
 
 	Ok(())
 }

--- a/tests/routes.rs
+++ b/tests/routes.rs
@@ -3,6 +3,7 @@
 use axum::{
 	body::Body,
 	http::{Request, StatusCode},
+	response::Response,
 };
 use http_body_util::BodyExt;
 use mockall::predicate;
@@ -17,8 +18,18 @@ use youtube_summarizer_server::web::{
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
+async fn body_to_string(res: Response) -> Result<String> {
+	let bytes = res
+		.into_body()
+		.collect()
+		.await?
+		.to_bytes()
+		.to_vec();
+	Ok(String::from_utf8(bytes)?)
+}
+
 #[sqlx::test]
-fn can_build_router(pool: PgPool) {
+fn can_build_router(pool: PgPool) -> Result<()> {
 	let routes = routes(pool);
 
 	let response = routes
@@ -28,18 +39,15 @@ fn can_build_router(pool: PgPool) {
 				.body(Body::empty())
 				.unwrap(),
 		)
-		.await
-		.unwrap();
+		.await?;
 
 	assert_eq!(response.status(), StatusCode::OK);
 
-	let body = response
-		.into_body()
-		.collect()
-		.await
-		.unwrap()
-		.to_bytes();
-	assert_eq!(&body[..], b"hello world");
+	let body = body_to_string(response).await?;
+
+	assert_eq!(body, "hello world");
+
+	Ok(())
 }
 
 const VTT: &str = include_str!("./test.vtt");
@@ -70,6 +78,29 @@ async fn should_get_and_cache_transcript(pool: PgPool) -> Result<()> {
 
 	let transcript = get_transcript_by_url(&url, &pool, yt_service).await?;
 	assert_eq!(transcript, CLEAN_VTT);
+
+	Ok(())
+}
+
+#[sqlx::test]
+async fn invalid_url(pool: PgPool) -> Result<()> {
+	let routes = routes(pool);
+
+	let response = routes
+		.oneshot(
+			Request::builder()
+				.uri("/transcript?url=invalid_url")
+				.body(Body::empty())
+				.unwrap(),
+		)
+		.await
+		.unwrap();
+
+	assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+	let body = body_to_string(response).await?;
+
+	assert_eq!(body, "Invalid URL");
 
 	Ok(())
 }

--- a/tests/routes.rs
+++ b/tests/routes.rs
@@ -10,10 +10,13 @@ use mockall::predicate;
 // for `collect`
 use sqlx::PgPool;
 use tower::ServiceExt; // for `call`, `oneshot`, and `ready`
-use youtube_summarizer_server::web::{
-	routes::routes,
-	services::{transcript::get_transcript_by_url, youtube::MockYtServiceTrait},
-	utils::YTUrl,
+use youtube_summarizer_server::{
+	error::ErrorMessage,
+	web::{
+		routes::routes,
+		services::{transcript::get_transcript_by_url, youtube::MockYtServiceTrait},
+		utils::YTUrl,
+	},
 };
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
@@ -91,18 +94,45 @@ async fn invalid_url(pool: PgPool) -> Result<()> {
 		.oneshot(
 			Request::builder()
 				.uri(format!("/transcript?url={invalid_url}"))
-				.body(Body::empty())
-				.unwrap(),
+				.body(Body::empty())?,
 		)
-		.await
-		.unwrap();
+		.await?;
 
 	assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 
 	let body = body_to_string(response).await?;
 
-	assert!(body.contains("Invalid URL"));
-	assert!(body.contains(invalid_url));
+	let ErrorMessage { error, message } = serde_json::from_str::<ErrorMessage>(&body)?;
+
+	assert!(message.contains("Invalid URL"));
+	assert!(message.contains(invalid_url));
+	assert!(error);
+
+	Ok(())
+}
+
+#[sqlx::test]
+async fn unsupported_url(pool: PgPool) -> Result<()> {
+	let invalid_url = "https://www.rustisamust.com/watch";
+	let routes = routes(pool);
+
+	let response = routes
+		.oneshot(
+			Request::builder()
+				.uri(format!("/transcript?url={invalid_url}"))
+				.body(Body::empty())?,
+		)
+		.await?;
+
+	assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+	let body = body_to_string(response).await?;
+
+	let ErrorMessage { error, message } = serde_json::from_str::<ErrorMessage>(&body)?;
+
+	assert!(message.contains("Unsupported URL"));
+	assert!(message.contains(invalid_url));
+	assert!(error);
 
 	Ok(())
 }


### PR DESCRIPTION

- **Test invalid URL and body to string helper**
- **Make YtUrl error more specific and include url in all error messages**
- **Return JSON for errors and tests for invalid and unsupported urls**
