### PR TITLE
summary tests

### DIFF
--- a/src/web.rs
+++ b/src/web.rs
@@ -1,4 +1,4 @@
-mod clients;
+pub mod clients;
 pub mod routes;
 pub mod services;
 pub mod utils;

--- a/src/web/clients.rs
+++ b/src/web/clients.rs
@@ -1,4 +1,4 @@
-mod completions;
+pub mod completions;
 mod yt_dlp;
 
 pub use completions::CompletionClient;

--- a/src/web/clients.rs
+++ b/src/web/clients.rs
@@ -2,5 +2,5 @@ mod completions;
 mod yt_dlp;
 
 pub use completions::CompletionClient;
-pub use completions::CompletionClientTrait;
+pub use completions::DeepInfraClient;
 pub use yt_dlp::YtdlpClientBuilder;

--- a/src/web/clients.rs
+++ b/src/web/clients.rs
@@ -2,4 +2,5 @@ mod completions;
 mod yt_dlp;
 
 pub use completions::CompletionClient;
+pub use completions::CompletionClientTrait;
 pub use yt_dlp::YtdlpClientBuilder;

--- a/src/web/clients/completions.rs
+++ b/src/web/clients/completions.rs
@@ -70,18 +70,18 @@ impl CompletionRequestBuilder {
 }
 
 #[automock]
-pub trait CompletionClientTrait {
+pub trait CompletionClient {
 	fn post(&self, prompt: &str, text: &str) -> impl Future<Output = Result<String>> + Send;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CompletionClient {
+pub struct DeepInfraClient {
 	model: String,
 	url: Url,
 	api_key: String,
 }
 
-impl CompletionClient {
+impl DeepInfraClient {
 	pub fn build(model: String, base_url: &Url, api_key: String) -> Result<Self> {
 		const COMPLETIONS_PATH: &str = "chat/completions";
 		Ok(Self {
@@ -114,11 +114,11 @@ impl CompletionClient {
 			.parse::<Url>()
 			.map_err(|_| Error::EnvMissingOrInvalid(OPEN_AI_BASE_URL))?;
 
-		CompletionClient::build(model, &url, api_key)
+		DeepInfraClient::build(model, &url, api_key)
 	}
 }
 
-impl CompletionClientTrait for CompletionClient {
+impl CompletionClient for DeepInfraClient {
 	async fn post(&self, prompt: &str, text: &str) -> Result<String> {
 		let payload = CompletionRequestBuilder::default()
 			.model(&self.model)

--- a/src/web/clients/completions.rs
+++ b/src/web/clients/completions.rs
@@ -1,6 +1,7 @@
 use crate::error::{Error, Result};
 use crate::web::services::env::load_env;
 use derive_builder::Builder;
+use mockall::automock;
 use reqwest::{Client, Url};
 use serde::{Deserialize, Serialize};
 use std::env;
@@ -68,6 +69,11 @@ impl CompletionRequestBuilder {
 	}
 }
 
+#[automock]
+pub trait CompletionClientTrait {
+	fn post(&self, prompt: &str, text: &str) -> impl Future<Output = Result<String>> + Send;
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CompletionClient {
 	model: String,
@@ -76,11 +82,26 @@ pub struct CompletionClient {
 }
 
 impl CompletionClient {
+	pub fn build(model: String, base_url: &Url, api_key: String) -> Result<Self> {
+		const COMPLETIONS_PATH: &str = "chat/completions";
+		Ok(Self {
+			model,
+			url: base_url
+				.join(COMPLETIONS_PATH)
+				.map_err(|_| {
+					format!(
+						"could not parse completions endpoint: {}",
+						base_url.as_str()
+					)
+				})?,
+			api_key,
+		})
+	}
+
 	pub fn from_env() -> Result<Self> {
 		const OPEN_AI_API_KEY: &str = "OPEN_AI_API_KEY";
 		const OPEN_AI_MODEL: &str = "OPEN_AI_MODEL";
 		const OPEN_AI_BASE_URL: &str = "OPEN_AI_BASE_URL";
-		const COMPLETIONS_PATH: &str = "chat/completions";
 
 		load_env()?;
 
@@ -91,17 +112,14 @@ impl CompletionClient {
 		let url = env::var(OPEN_AI_BASE_URL)
 			.map_err(|_| Error::EnvMissingOrInvalid(OPEN_AI_BASE_URL))?
 			.parse::<Url>()
-			.and_then(|x| x.join(COMPLETIONS_PATH))
 			.map_err(|_| Error::EnvMissingOrInvalid(OPEN_AI_BASE_URL))?;
 
-		Ok(Self {
-			model,
-			url,
-			api_key,
-		})
+		CompletionClient::build(model, &url, api_key)
 	}
+}
 
-	pub async fn post(&self, prompt: &str, text: &str) -> Result<String> {
+impl CompletionClientTrait for CompletionClient {
+	async fn post(&self, prompt: &str, text: &str) -> Result<String> {
 		let payload = CompletionRequestBuilder::default()
 			.model(&self.model)
 			.max_tokens(700_u32)

--- a/src/web/clients/completions.rs
+++ b/src/web/clients/completions.rs
@@ -1,7 +1,6 @@
 use crate::error::{Error, Result};
 use crate::web::services::env::load_env;
 use derive_builder::Builder;
-use mockall::automock;
 use reqwest::{Client, Url};
 use serde::{Deserialize, Serialize};
 use std::env;
@@ -69,7 +68,6 @@ impl CompletionRequestBuilder {
 	}
 }
 
-#[automock]
 pub trait CompletionClient {
 	fn post(&self, prompt: &str, text: &str) -> impl Future<Output = Result<String>> + Send;
 }

--- a/src/web/routes/transcript.rs
+++ b/src/web/routes/transcript.rs
@@ -1,4 +1,5 @@
 use crate::error::Result;
+use crate::web::clients::CompletionClient;
 use crate::web::services::transcript;
 use crate::web::services::youtube::YtService;
 use crate::web::utils::YTUrl;
@@ -41,11 +42,18 @@ async fn summarize(
 	Query(SummaryParams { url }): Query<SummaryParams>,
 	State(pool): State<PgPool>,
 ) -> Result<(StatusCode, Json<Value>)> {
+	let summary = transcript::summarize_by_url(
+		&url.as_str().try_into()?,
+		&pool,
+		YtService::from_env()?,
+		&CompletionClient::from_env()?,
+	)
+	.await?;
 	Ok((
 		StatusCode::OK,
 		Json(json!(
 				{
-					"summary": transcript::summarize_by_url(&url.as_str().try_into()?, &pool, YtService::from_env()?).await?,
+					"summary": summary
 				}
 		)),
 	))

--- a/src/web/routes/transcript.rs
+++ b/src/web/routes/transcript.rs
@@ -1,7 +1,7 @@
 use crate::error::Result;
 use crate::web::clients::DeepInfraClient;
 use crate::web::services::transcript;
-use crate::web::services::youtube::YtService;
+use crate::web::services::youtube::YtDlpService;
 use crate::web::utils::YTUrl;
 use axum::extract::State;
 use axum::{Json, Router, extract::Query, http::StatusCode, routing::get};
@@ -20,9 +20,12 @@ async fn transcript(
 	Query(TranscriptParams { url }): Query<TranscriptParams>,
 	State(pool): State<PgPool>,
 ) -> Result<(StatusCode, Json<Value>)> {
-	let transcript =
-		transcript::get_transcript_by_url(&url.as_str().try_into()?, &pool, YtService::from_env()?)
-			.await?;
+	let transcript = transcript::get_transcript_by_url(
+		&url.as_str().try_into()?,
+		&pool,
+		YtDlpService::from_env()?,
+	)
+	.await?;
 	Ok((
 		StatusCode::OK,
 		Json(json!(
@@ -45,7 +48,7 @@ async fn summarize(
 	let summary = transcript::summarize_by_url(
 		&url.as_str().try_into()?,
 		&pool,
-		YtService::from_env()?,
+		YtDlpService::from_env()?,
 		&DeepInfraClient::from_env()?,
 	)
 	.await?;

--- a/src/web/routes/transcript.rs
+++ b/src/web/routes/transcript.rs
@@ -45,7 +45,7 @@ async fn summarize(
 		StatusCode::OK,
 		Json(json!(
 				{
-					"summary": transcript::summarize_by_url(&url.as_str().try_into()?, &pool).await?,
+					"summary": transcript::summarize_by_url(&url.as_str().try_into()?, &pool, YtService::from_env()?).await?,
 				}
 		)),
 	))

--- a/src/web/routes/transcript.rs
+++ b/src/web/routes/transcript.rs
@@ -1,5 +1,5 @@
 use crate::error::Result;
-use crate::web::clients::CompletionClient;
+use crate::web::clients::DeepInfraClient;
 use crate::web::services::transcript;
 use crate::web::services::youtube::YtService;
 use crate::web::utils::YTUrl;
@@ -46,7 +46,7 @@ async fn summarize(
 		&url.as_str().try_into()?,
 		&pool,
 		YtService::from_env()?,
-		&CompletionClient::from_env()?,
+		&DeepInfraClient::from_env()?,
 	)
 	.await?;
 	Ok((

--- a/src/web/services/transcript.rs
+++ b/src/web/services/transcript.rs
@@ -3,7 +3,7 @@ use crate::prompts::{
 	CHUNKED_COMBINE_TEMPLATE, CHUNKED_SUMMARY_TEMPLATE, ONESHOT_SUMMARY_TEMPLATE,
 };
 use crate::web::clients::{CompletionClient, DeepInfraClient};
-use crate::web::services::youtube::YtServiceTrait;
+use crate::web::services::youtube::YtService;
 use crate::web::utils::YTUrl;
 use core::time::Duration;
 use regex::Regex;
@@ -15,7 +15,7 @@ use tokio::time::timeout;
 pub async fn get_transcript_by_url(
 	url: &YTUrl,
 	pool: &PgPool,
-	yt_service: impl YtServiceTrait + Send + Sync + 'static,
+	yt_service: impl YtService + Send + Sync + 'static,
 ) -> Result<String> {
 	let transcript = if let Ok(row) =
 		sqlx::query!("SELECT subtitles FROM videos WHERE video_id = $1", url.id())
@@ -51,7 +51,7 @@ pub async fn get_transcript_by_url(
 pub async fn summarize_by_url(
 	url: &YTUrl,
 	pool: &PgPool,
-	yt_service: impl YtServiceTrait + Send + Sync + 'static,
+	yt_service: impl YtService + Send + Sync + 'static,
 	client: &DeepInfraClient,
 ) -> Result<String> {
 	let summary = if let Ok(row) = sqlx::query!(

--- a/src/web/services/transcript.rs
+++ b/src/web/services/transcript.rs
@@ -2,7 +2,7 @@ use crate::error::Result;
 use crate::prompts::{
 	CHUNKED_COMBINE_TEMPLATE, CHUNKED_SUMMARY_TEMPLATE, ONESHOT_SUMMARY_TEMPLATE,
 };
-use crate::web::clients::CompletionClient;
+use crate::web::clients::{CompletionClient, CompletionClientTrait};
 use crate::web::services::youtube::YtServiceTrait;
 use crate::web::utils::YTUrl;
 use core::time::Duration;
@@ -90,13 +90,23 @@ pub async fn summarize_by_url(
 	Ok(summary)
 }
 
-async fn single_chunk_summary(client: &CompletionClient, transcript: &str) -> Result<String> {
+async fn single_chunk_summary(
+	client: &impl CompletionClientTrait,
+	transcript: &str,
+) -> Result<String> {
 	client
 		.post(ONESHOT_SUMMARY_TEMPLATE, transcript)
 		.await
 }
+
+async fn summarize_chunk(client: impl CompletionClientTrait, chunk: String) -> Result<String> {
+	client
+		.post(CHUNKED_SUMMARY_TEMPLATE, &chunk)
+		.await
+}
+
 async fn multi_chunk_summary(
-	client: &CompletionClient,
+	client: &(impl CompletionClientTrait + Clone + Send + Sync + 'static),
 	transcript: &str,
 	size: usize,
 	overlap: usize,
@@ -112,12 +122,6 @@ async fn multi_chunk_summary(
 	}
 	tracing::debug!("using chunked prompts");
 
-	let summarize_chunk = async |client: CompletionClient, x: String| {
-		client
-			.clone()
-			.post(CHUNKED_SUMMARY_TEMPLATE, &x)
-			.await
-	};
 	let combine_chunks = async |x: Vec<String>| {
 		let combined = x
 			.iter()
@@ -128,7 +132,7 @@ async fn multi_chunk_summary(
 
 		tracing::debug!(combined);
 
-		CompletionClient::from_env()?
+		client
 			.post(CHUNKED_COMBINE_TEMPLATE, &combined)
 			.await
 	};

--- a/src/web/services/transcript.rs
+++ b/src/web/services/transcript.rs
@@ -52,6 +52,7 @@ pub async fn summarize_by_url(
 	url: &YTUrl,
 	pool: &PgPool,
 	yt_service: impl YtServiceTrait + Send + Sync + 'static,
+	client: &CompletionClient,
 ) -> Result<String> {
 	let summary = if let Ok(row) = sqlx::query!(
 		r"
@@ -71,7 +72,7 @@ pub async fn summarize_by_url(
 		let transcript = get_transcript_by_url(url, pool, yt_service).await?;
 		tracing::debug!("transcript len: {}", transcript.len());
 
-		let summary = multi_chunk_summary(&transcript, 10_000, 100).await?;
+		let summary = multi_chunk_summary(client, &transcript, 10_000, 100).await?;
 
 		tracing::debug!("summarized transcript");
 
@@ -89,12 +90,17 @@ pub async fn summarize_by_url(
 	Ok(summary)
 }
 
-async fn single_chunk_summary(transcript: &str) -> Result<String> {
-	CompletionClient::from_env()?
+async fn single_chunk_summary(client: &CompletionClient, transcript: &str) -> Result<String> {
+	client
 		.post(ONESHOT_SUMMARY_TEMPLATE, transcript)
 		.await
 }
-async fn multi_chunk_summary(transcript: &str, size: usize, overlap: usize) -> Result<String> {
+async fn multi_chunk_summary(
+	client: &CompletionClient,
+	transcript: &str,
+	size: usize,
+	overlap: usize,
+) -> Result<String> {
 	let chunks = chunk_text_by_words(transcript, size, overlap);
 	let len = chunks.len();
 
@@ -102,12 +108,13 @@ async fn multi_chunk_summary(transcript: &str, size: usize, overlap: usize) -> R
 
 	if len == 1 {
 		tracing::debug!("using oneshot prompt");
-		return single_chunk_summary(transcript).await;
+		return single_chunk_summary(client, transcript).await;
 	}
 	tracing::debug!("using chunked prompts");
 
-	let summarize_chunk = async |x: String| {
-		CompletionClient::from_env()?
+	let summarize_chunk = async |client: CompletionClient, x: String| {
+		client
+			.clone()
 			.post(CHUNKED_SUMMARY_TEMPLATE, &x)
 			.await
 	};
@@ -128,7 +135,7 @@ async fn multi_chunk_summary(transcript: &str, size: usize, overlap: usize) -> R
 
 	let summaries = chunks
 		.into_iter()
-		.map(summarize_chunk)
+		.map(|x| summarize_chunk(client.clone(), x))
 		.collect::<JoinSet<_>>()
 		.join_all()
 		.await

--- a/src/web/services/transcript.rs
+++ b/src/web/services/transcript.rs
@@ -3,7 +3,7 @@ use crate::prompts::{
 	CHUNKED_COMBINE_TEMPLATE, CHUNKED_SUMMARY_TEMPLATE, ONESHOT_SUMMARY_TEMPLATE,
 };
 use crate::web::clients::CompletionClient;
-use crate::web::services::youtube::{YtService, YtServiceTrait};
+use crate::web::services::youtube::YtServiceTrait;
 use crate::web::utils::YTUrl;
 use core::time::Duration;
 use regex::Regex;
@@ -48,7 +48,11 @@ pub async fn get_transcript_by_url(
 	Ok(transcript)
 }
 
-pub async fn summarize_by_url(url: &YTUrl, pool: &PgPool) -> Result<String> {
+pub async fn summarize_by_url(
+	url: &YTUrl,
+	pool: &PgPool,
+	yt_service: impl YtServiceTrait + Send + Sync + 'static,
+) -> Result<String> {
 	let summary = if let Ok(row) = sqlx::query!(
 		r"
 			SELECT summary 
@@ -64,7 +68,7 @@ pub async fn summarize_by_url(url: &YTUrl, pool: &PgPool) -> Result<String> {
 		row.summary
 			.expect("Summary should not be null")
 	} else {
-		let transcript = get_transcript_by_url(url, pool, YtService::from_env()?).await?;
+		let transcript = get_transcript_by_url(url, pool, yt_service).await?;
 		tracing::debug!("transcript len: {}", transcript.len());
 
 		let summary = multi_chunk_summary(&transcript, 10_000, 100).await?;

--- a/src/web/services/transcript.rs
+++ b/src/web/services/transcript.rs
@@ -2,7 +2,7 @@ use crate::error::Result;
 use crate::prompts::{
 	CHUNKED_COMBINE_TEMPLATE, CHUNKED_SUMMARY_TEMPLATE, ONESHOT_SUMMARY_TEMPLATE,
 };
-use crate::web::clients::{CompletionClient, CompletionClientTrait};
+use crate::web::clients::{CompletionClient, DeepInfraClient};
 use crate::web::services::youtube::YtServiceTrait;
 use crate::web::utils::YTUrl;
 use core::time::Duration;
@@ -52,7 +52,7 @@ pub async fn summarize_by_url(
 	url: &YTUrl,
 	pool: &PgPool,
 	yt_service: impl YtServiceTrait + Send + Sync + 'static,
-	client: &CompletionClient,
+	client: &DeepInfraClient,
 ) -> Result<String> {
 	let summary = if let Ok(row) = sqlx::query!(
 		r"
@@ -90,23 +90,20 @@ pub async fn summarize_by_url(
 	Ok(summary)
 }
 
-async fn single_chunk_summary(
-	client: &impl CompletionClientTrait,
-	transcript: &str,
-) -> Result<String> {
+async fn single_chunk_summary(client: &impl CompletionClient, transcript: &str) -> Result<String> {
 	client
 		.post(ONESHOT_SUMMARY_TEMPLATE, transcript)
 		.await
 }
 
-async fn summarize_chunk(client: impl CompletionClientTrait, chunk: String) -> Result<String> {
+async fn summarize_chunk(client: impl CompletionClient, chunk: String) -> Result<String> {
 	client
 		.post(CHUNKED_SUMMARY_TEMPLATE, &chunk)
 		.await
 }
 
 async fn multi_chunk_summary(
-	client: &(impl CompletionClientTrait + Clone + Send + Sync + 'static),
+	client: &(impl CompletionClient + Clone + Send + Sync + 'static),
 	transcript: &str,
 	size: usize,
 	overlap: usize,

--- a/src/web/services/transcript.rs
+++ b/src/web/services/transcript.rs
@@ -2,7 +2,7 @@ use crate::error::Result;
 use crate::prompts::{
 	CHUNKED_COMBINE_TEMPLATE, CHUNKED_SUMMARY_TEMPLATE, ONESHOT_SUMMARY_TEMPLATE,
 };
-use crate::web::clients::{CompletionClient, DeepInfraClient};
+use crate::web::clients::CompletionClient;
 use crate::web::services::youtube::YtService;
 use crate::web::utils::YTUrl;
 use core::time::Duration;
@@ -52,7 +52,7 @@ pub async fn summarize_by_url(
 	url: &YTUrl,
 	pool: &PgPool,
 	yt_service: impl YtService + Send + Sync + 'static,
-	client: &DeepInfraClient,
+	client: &(impl CompletionClient + Clone + Send + Sync + 'static),
 ) -> Result<String> {
 	let summary = if let Ok(row) = sqlx::query!(
 		r"

--- a/src/web/services/transcript.rs
+++ b/src/web/services/transcript.rs
@@ -72,7 +72,7 @@ pub async fn summarize_by_url(
 		let transcript = get_transcript_by_url(url, pool, yt_service).await?;
 		tracing::debug!("transcript len: {}", transcript.len());
 
-		let summary = multi_chunk_summary(client, &transcript, 10_000, 100).await?;
+		let summary = summary(client, &transcript, 10_000, 100).await?;
 
 		tracing::debug!("summarized transcript");
 
@@ -90,19 +90,19 @@ pub async fn summarize_by_url(
 	Ok(summary)
 }
 
-async fn single_chunk_summary(client: &impl CompletionClient, transcript: &str) -> Result<String> {
+async fn oneshot_summary(client: &impl CompletionClient, transcript: &str) -> Result<String> {
 	client
 		.post(ONESHOT_SUMMARY_TEMPLATE, transcript)
 		.await
 }
 
-async fn summarize_chunk(client: impl CompletionClient, chunk: String) -> Result<String> {
+async fn chunk_summary(client: impl CompletionClient, chunk: String) -> Result<String> {
 	client
 		.post(CHUNKED_SUMMARY_TEMPLATE, &chunk)
 		.await
 }
 
-async fn multi_chunk_summary(
+async fn summary(
 	client: &(impl CompletionClient + Clone + Send + Sync + 'static),
 	transcript: &str,
 	size: usize,
@@ -115,35 +115,40 @@ async fn multi_chunk_summary(
 
 	if len == 1 {
 		tracing::debug!("using oneshot prompt");
-		return single_chunk_summary(client, transcript).await;
+		return oneshot_summary(client, transcript).await;
 	}
 	tracing::debug!("using chunked prompts");
 
-	let combine_chunks = async |x: Vec<String>| {
-		let combined = x
-			.iter()
-			.enumerate()
-			.map(|(i, summary)| format!("chunk {}/{}\n{summary}", i + 1, len))
-			.collect::<Vec<_>>()
-			.join("\n");
+	multi_chunk_summary(client, chunks).await
+}
 
-		tracing::debug!(combined);
-
-		client
-			.post(CHUNKED_COMBINE_TEMPLATE, &combined)
-			.await
-	};
+async fn multi_chunk_summary(
+	client: &(impl CompletionClient + Clone + Send + Sync + 'static),
+	chunks: Vec<String>,
+) -> Result<String> {
+	let len = chunks.len();
 
 	let summaries = chunks
 		.into_iter()
-		.map(|x| summarize_chunk(client.clone(), x))
+		.map(|x| chunk_summary(client.clone(), x))
 		.collect::<JoinSet<_>>()
 		.join_all()
 		.await
 		.into_iter()
 		.collect::<Result<Vec<String>>>()?;
 
-	combine_chunks(summaries).await
+	let combined = summaries
+		.iter()
+		.enumerate()
+		.map(|(i, summary)| format!("chunk {}/{}\n{summary}", i + 1, len))
+		.collect::<Vec<_>>()
+		.join("\n");
+
+	tracing::debug!(combined);
+
+	client
+		.post(CHUNKED_COMBINE_TEMPLATE, &combined)
+		.await
 }
 
 /// remove timestamps and duplicate lines

--- a/src/web/services/youtube.rs
+++ b/src/web/services/youtube.rs
@@ -8,16 +8,16 @@ use mockall::automock;
 use reqwest::Url;
 
 #[automock]
-pub trait YtServiceTrait {
+pub trait YtService {
 	fn fetch_captions(&self, url: &YTUrl) -> Result<String>;
 }
 
-pub struct YtService {
+pub struct YtDlpService {
 	retries: u8,
 	proxy: Url,
 }
 
-impl YtService {
+impl YtDlpService {
 	pub fn new(retries: u8, proxy: Url) -> Self {
 		Self { retries, proxy }
 	}
@@ -39,7 +39,7 @@ impl YtService {
 	}
 }
 
-impl YtServiceTrait for YtService {
+impl YtService for YtDlpService {
 	fn fetch_captions(&self, url: &YTUrl) -> Result<String> {
 		YtdlpClientBuilder::default()
 			.proxy(self.proxy.clone())

--- a/tests/routes.rs
+++ b/tests/routes.rs
@@ -85,15 +85,13 @@ async fn should_get_and_cache_transcript(pool: PgPool) -> Result<()> {
 	Ok(())
 }
 
-#[sqlx::test]
-async fn invalid_url(pool: PgPool) -> Result<()> {
-	let invalid_url = "uhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh";
+async fn transcript_error(pool: PgPool, url: &str, error_message: &str) -> Result<()> {
 	let routes = routes(pool);
 
 	let response = routes
 		.oneshot(
 			Request::builder()
-				.uri(format!("/transcript?url={invalid_url}"))
+				.uri(format!("/transcript?url={url}"))
 				.body(Body::empty())?,
 		)
 		.await?;
@@ -104,35 +102,23 @@ async fn invalid_url(pool: PgPool) -> Result<()> {
 
 	let ErrorMessage { error, message } = serde_json::from_str::<ErrorMessage>(&body)?;
 
-	assert!(message.contains("Invalid URL"));
-	assert!(message.contains(invalid_url));
+	assert!(message.contains(error_message));
+	assert!(message.contains(url));
 	assert!(error);
 
 	Ok(())
 }
 
 #[sqlx::test]
+async fn invalid_url(pool: PgPool) -> Result<()> {
+	let url = "uhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh";
+	let error_message = "Invalid URL";
+	transcript_error(pool, url, error_message).await
+}
+
+#[sqlx::test]
 async fn unsupported_url(pool: PgPool) -> Result<()> {
-	let invalid_url = "https://www.rustisamust.com/watch";
-	let routes = routes(pool);
-
-	let response = routes
-		.oneshot(
-			Request::builder()
-				.uri(format!("/transcript?url={invalid_url}"))
-				.body(Body::empty())?,
-		)
-		.await?;
-
-	assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-
-	let body = body_to_string(response).await?;
-
-	let ErrorMessage { error, message } = serde_json::from_str::<ErrorMessage>(&body)?;
-
-	assert!(message.contains("Unsupported URL"));
-	assert!(message.contains(invalid_url));
-	assert!(error);
-
-	Ok(())
+	let url = "https://www.rustisamust.com/watch";
+	let error_message = "Unsupported URL";
+	transcript_error(pool, url, error_message).await
 }

--- a/tests/routes.rs
+++ b/tests/routes.rs
@@ -6,15 +6,20 @@ use axum::{
 	response::Response,
 };
 use http_body_util::BodyExt;
-use mockall::predicate;
+use mockall::{mock, predicate};
 // for `collect`
 use sqlx::PgPool;
 use tower::ServiceExt; // for `call`, `oneshot`, and `ready`
 use youtube_summarizer_server::{
 	error::ErrorMessage,
+	prompts::ONESHOT_SUMMARY_TEMPLATE,
 	web::{
+		clients::CompletionClient,
 		routes::routes,
-		services::{transcript::get_transcript_by_url, youtube::MockYtService},
+		services::{
+			transcript::{get_transcript_by_url, summarize_by_url},
+			youtube::MockYtService,
+		},
 		utils::YTUrl,
 	},
 };
@@ -81,6 +86,56 @@ async fn should_get_and_cache_transcript(pool: PgPool) -> Result<()> {
 
 	let transcript = get_transcript_by_url(&url, &pool, yt_service).await?;
 	assert_eq!(transcript, CLEAN_VTT);
+
+	Ok(())
+}
+
+mock! {
+	pub Completion {}
+	impl CompletionClient for Completion {
+		fn post(&self, prompt: &str, text: &str) -> impl Future<Output = youtube_summarizer_server::error::Result<String>> + Send;
+	}
+	impl Clone for Completion {
+		fn clone(&self) -> Self;
+	}
+}
+#[sqlx::test]
+async fn should_get_and_cache_summary(pool: PgPool) -> Result<()> {
+	let url = YTUrl::try_from(
+		"https://www.youtube.com/watch?v=DjcC6p_8fpE&pp=ygUWamFjb2IgYXNwZXIgdHlwZXNjcmlwdA%3D%3D",
+	)?;
+	let summary = "Cheese is scrumptious";
+
+	let mut yt_service = MockYtService::new();
+	yt_service
+		.expect_fetch_captions()
+		.with(predicate::eq(url.clone()))
+		.times(1)
+		.returning(|_url| Ok(VTT.to_owned()));
+
+	let mut client = MockCompletion::new();
+	client
+		.expect_post()
+		.with(
+			predicate::eq(ONESHOT_SUMMARY_TEMPLATE),
+			predicate::eq(CLEAN_VTT),
+		)
+		.times(1)
+		.returning(|_prompt, _text| Box::pin(async { Ok(summary.to_owned()) }));
+
+	let res = summarize_by_url(&url, &pool, yt_service, &client).await?;
+	assert_eq!(res, summary);
+
+	let mut yt_service = MockYtService::new();
+	yt_service
+		.expect_fetch_captions()
+		.times(0);
+
+	let mut client = MockCompletion::new();
+	client.expect_post().times(0);
+
+	let res = summarize_by_url(&url, &pool, yt_service, &client).await?;
+	assert_eq!(res, summary);
 
 	Ok(())
 }

--- a/tests/routes.rs
+++ b/tests/routes.rs
@@ -14,7 +14,7 @@ use youtube_summarizer_server::{
 	error::ErrorMessage,
 	web::{
 		routes::routes,
-		services::{transcript::get_transcript_by_url, youtube::MockYtServiceTrait},
+		services::{transcript::get_transcript_by_url, youtube::MockYtService},
 		utils::YTUrl,
 	},
 };
@@ -63,7 +63,7 @@ async fn should_get_and_cache_transcript(pool: PgPool) -> Result<()> {
 		"https://www.youtube.com/watch?v=DjcC6p_8fpE&pp=ygUWamFjb2IgYXNwZXIgdHlwZXNjcmlwdA%3D%3D",
 	)?;
 
-	let mut yt_service = MockYtServiceTrait::new();
+	let mut yt_service = MockYtService::new();
 	yt_service
 		.expect_fetch_captions()
 		.with(predicate::eq(url.clone()))
@@ -74,7 +74,7 @@ async fn should_get_and_cache_transcript(pool: PgPool) -> Result<()> {
 	assert_eq!(transcript, CLEAN_VTT);
 
 	// should be stored in DB
-	let mut yt_service = MockYtServiceTrait::new();
+	let mut yt_service = MockYtService::new();
 	yt_service
 		.expect_fetch_captions()
 		.times(0);


### PR DESCRIPTION
- **Refactor tests**
- **Pass yt service from route instead of building in service**
- **Pass completion client down into service from route**
- **Lots of fun trait bounds to make Completion client a trait**
- **Rename completion client trait and completion client to more descriptive names**
- **Rename yt service trait as well**
- **Refactor summary functions**
- **Test caching oneshot summary**
